### PR TITLE
Solve missing return compiler warnings/errors

### DIFF
--- a/include/CCLLink.h
+++ b/include/CCLLink.h
@@ -198,7 +198,7 @@ public:
     }
     // returns true if the best adjacency position has already been used
     bool BestIsUsed(unsigned int UnitSide) {
-        m_pUnit[UnitSide]->AdjUsed(BestAdjPos(UnitSide));
+        return m_pUnit[UnitSide]->AdjUsed(BestAdjPos(UnitSide));
     }
     // return a pointer to the unit on the given side
     // (LEFT - prefix unit, RIGHT - last unit).

--- a/include/CCLSet.h
+++ b/include/CCLSet.h
@@ -48,6 +48,7 @@ struct SLinkPair
     SLinkPair& operator=(SLinkPair const& LinkPair) {
         m_End = LinkPair.m_End;
         m_Depth = LinkPair.m_Depth;
+        return *this;
     }
 };
 

--- a/include/StatTable.h
+++ b/include/StatTable.h
@@ -177,7 +177,7 @@ public:
             yPError(ERR_OUT_OF_RANGE, "property not supported by table");
         }
 
-        m_pLastVal = IncStrength(*pKey, Code, Strg);
+        m_pLastVal = this->IncStrength(*pKey, Code, Strg);
         m_pLastKey = CStrengths<K, V>::GetKey();
     }
     // Same as above, but for the entry currently cached.
@@ -191,7 +191,7 @@ public:
             yPError(ERR_OUT_OF_RANGE, "property not supported by table");
         }
 
-        IncStrength(m_pLastVal, Code, Strg);
+        this->IncStrength(m_pLastVal, Code, Strg);
     }
     
     // Get the number of entries in the top list

--- a/include/Strength.h
+++ b/include/Strength.h
@@ -48,6 +48,7 @@ public:
         m_Strg = Ent.m_Strg;
         m_Data = Ent.m_Data;
         m_Props = Ent.m_Props;
+        return *this;
     }
     CRef* GetData() { return (CRef*)m_Data; }
     float GetStrg() { return m_Strg; }


### PR DESCRIPTION
Newer compiler versions raise warnings or even errors for missing
returns in non-void methods, even if control would never reach the
end of this particular method.

This PR contains a few changes that allow the parser to run without
errors for newer compiler versions (for gcc 4.2.1, I didn't
 check for other compilers) by:
* adding explicit returns to a number of functions
* adding type declarations to some undeclared variables